### PR TITLE
Add manpages

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -19,6 +19,6 @@
 
 ACLOCAL_AMFLAGS = -I config
 
-SUBDIRS = include lib tools tests
+SUBDIRS = include lib man tools tests
 
 EXTRA_DIST = LICENSE README.md

--- a/configure.ac
+++ b/configure.ac
@@ -116,6 +116,7 @@ AC_DEFINE_UNQUOTED([TRM_NOPS_LEN], [$TRM_NOPS_LEN],
 AC_CONFIG_FILES([Makefile
 		 include/Makefile
 		 lib/Makefile
+		 man/Makefile
 		 tests/Makefile
 		 tools/Makefile])
 

--- a/man/Makefile.am
+++ b/man/Makefile.am
@@ -1,0 +1,10 @@
+dist_man1_MANS = \
+  ulp_post.1 \
+  ulp_packer.1 \
+  ulp_reverse.1 \
+  ulp_dump.1 \
+  ulp_trigger.1 \
+  ulp_check.1
+
+dist_man7_MANS = \
+  libpulp.7

--- a/man/libpulp.7
+++ b/man/libpulp.7
@@ -1,0 +1,353 @@
+.\" libpulp - User-space Livepatching Library
+.\"
+.\" Copyright (C) 2021 SUSE Software Solutions GmbH
+.\"
+.\" This file is part of libpulp.
+.\"
+.\" libpulp is free software; you can redistribute it and/or
+.\" modify it under the terms of the GNU Lesser General Public
+.\" License as published by the Free Software Foundation; either
+.\" version 2.1 of the License, or (at your option) any later version.
+.\"
+.\" libpulp is distributed in the hope that it will be useful,
+.\" but WITHOUT ANY WARRANTY; without even the implied warranty of
+.\" MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+.\" Lesser General Public License for more details.
+.\"
+.\" You should have received a copy of the GNU General Public License
+.\" along with libpulp.  If not, see <http://www.gnu.org/licenses/>.
+
+.TH LIBPULP 7 "" "" "Libpulp Overview"
+.SH NAME
+Libpulp \- Userspace Live Patching
+.SH INTRODUCTION
+Libpulp is a framework that enables live patching of userspace processes. In
+other words, it allows that a running process be modified without restarting
+the whole application. Libpulp is composed of a library, which provides live
+patching capabilities to running processes, as well as of a collection of tools
+to trigger live patching operations.
+.SH REQUIREMENTS AND RESTRICTIONS
+.PP
+The following requirements and restrictions must be met for live patching
+operations to work:
+.TP
+.B Process Startup
+Live patches cannot be applied to every process in the system. In order for a
+process to be eligible for live patching, it must dynamically load libpulp.so,
+the runtime support for live patching operations. Typically, dynamically linked
+libraries needed by a program are automatically loaded into memory during
+process initialization. However, since live patching operations are not
+triggered by the program itself (but from an external tool), there is no real
+dependency, and libpulp.so might be missing from DT_NEEDED entries (see
+ld.so(8)). To bridge this gap, processes should be started with
+LD_PRELOAD=libpulp.so.
+.TP
+.B Target Libraries Rebuilding
+Not every library in the system is eligible for live patching, only those that
+have been previously prepared to be so. These are referred to as
+.IR "target libraries" "."
+Making a target library does not require changes to its source code, however it
+requires:
+.\" XXX: Describe why 40,38 is the argument to -fpatchable-function-entry.
+1. rebuilding the library with patchable function entries (see
+.IR -fpatchable-function-entry
+in
+.IR gcc (1));
+.\" XXX: Library entrance tracking is likely to be removed from the project.
+2. linking against the library entrance tracking object,
+.IR trm.S/trm.o ,
+see LIBRARY ENTRANCE TRACKING;
+3. post-processing it with
+.IR ulp_post (1).
+.TP
+.B Patch Granularity
+Live patches cannot be applied to arbitrarily tiny bits of a program. When a
+live patch is applied, it replaces entire functions at a time.
+.TP
+.B Function visibility
+Live patches cannot be applied to every function in a process. First, only
+functions belonging to shared libraries can be live patched; functions in the
+application itself, or functions linked from static libraries are not eligible.
+Secondly, only externally visible (GLOBAL or WEAK) functions can be targets of
+a live patch.
+.TP
+.B Process Permissions
+Libpulp uses ptrace to attach to target processes, thus only the owner of a
+process (or root) can apply a live patch to it. Moreover, on systems that have
+Linux Security Modules (LSM) enabled, some extra convincing might be required
+(see Ptrace access mode checking in
+.IR ptrace (2)).
+.SH TOOLS
+Creating and applying live patches is achieved with the following tools:
+.TP 16
+.BR ulp_post (1)
+.\" XXX: Library entrance tracking is likely to be removed from the project.
+Takes the library file passed as argument and installs trampolines to every
+exported function that has a patchable function entry (see
+.IR gcc (1)),
+making them live patchable.
+.TP 16
+.BR ulp_packer (1)
+Creates a live patch metadata file based on the live patch description file
+that it takes as argument. The metadata file can later be used by
+.IR ulp_trigger (1)
+to actually apply the live patch to a running process. For more information
+about the description file format, see the METADATA section.
+.TP 16
+.BR ulp_reverse (1)
+Opens the metadata file passed as argument and creates a new metadata file that
+can be used to reverse a previously applied live patch.
+.TP 16
+.BR ulp_dump (1)
+Parses the metadata file passed as argument and prints its contents in
+human-readable format.
+.TP 16
+.BR ulp_trigger (1)
+Applies the live patch described by the metadata file received as argument to
+the process with the specified
+.IR pid .
+.TP 16
+.BR ulp_check (1)
+Checks if the live patch referred to by the metadata file has already been
+applied to the process with the specified
+.IR pid .
+.SH ANATOMY OF LIVE PATCHES
+A live patch is very simple. It is composed of a dynamic shared object (DSO)
+containing replacement functions, and of a metadata file describing which
+target library and functions they are meant for. The DSO is no different than a
+regular shared library, in the sense that it is built from regular source code
+into a shared object. The metadata is described below.
+.SH METADATA
+A metadata file describes a live patch. It contanis three pieces of
+information:
+.TP
+.B Path to live patch DSO
+Live patching operates on a function-by-function basis (see Patch Granularity).
+These functions are provided in a dynamic shared object file. The absolute path
+to this file is recorded in the metadata.
+.TP
+.B Path to the target library DSO
+Each live patch contains replacement functions for a specific library. The
+absolute path to the in-disk location of the library is recorded in the
+metadata. Libpulp compares this path against the memory mappings of the target
+process, as provided by
+.IR procfs (5).
+.TP
+.B List of replacement functions
+Libpulp needs a correlation between original functions in the target library
+and replacement functions provided by the live patch. This correlation is
+recorded in the metadata file as a list of pairs of functions.
+.TP
+.B Description file format
+The metadata file is created based on a description file. The description file
+is rather simple. The first line contains the absolute path to the live patch
+DSO. The second line starts with the '@' character, immediately followed by the
+absolute path to the target library DSO. Finally, all following lines provide
+the list of replacement function, where each line starts with the name of the
+original function, followed by a colon, then by the name of the replacement
+function.
+.IP
+For example, a live patch to the math library could have a description file
+that looked like the following snippet (paths may differ across distributions):
+.RS
+.IP
+.EX
+\&
+/usr/lib64/livepatches/libm_livepatch_20210514.so
+@/lib64/libm.so.6
+hypot:hypot_v2
+gamma:new_gamma
+atan:atan_new
+.EE
+.RE
+.PP
+Notice, however, that even though the paths mentioned above refer to files in
+storage, the patches are not applied to the files themselves. Rather, they are
+applied to running processes that have loaded these files. See
+.IR ulp_trigger (1).
+.SH EXAMPLES
+The programs and commands below demonstrate how to use Libpulp.
+.PP
+First, a live patchable library must be created and properly compiled:
+.TP
+.B Library source
+.EX
+\&
+#include <stdlib.h>
+#include <string.h>
+
+char *
+proverb(void)
+{
+  int selection;
+  char *result;
+  char *proverbs[] = {
+    "A picture is worth a thousand words",
+    "Actions speak louder than words",
+    "An apple a day keeps the doctor away",
+    "Birds of a feather flock together",
+    "Do not judge a book by its cover",
+    "Never look a gift horse in the mouth",
+    "Practice makes perfect",
+    "Slow and steady wins the race",
+    "There is no place like home",
+    "Too many cooks spoil the broth"
+  };
+
+  selection = rand() % (sizeof(proverbs) / sizeof(char *));
+  result = strdup(proverbs[selection]);
+
+  return result;
+}
+.EE
+.PP
+As explained in the Target Libraries Rebuilding section above, in order to be
+live patchable, a target library must be built with patchable function entries.
+.\" XXX: Library entrance tracking is likely to be removed from the project.
+Apart from that, it must include the library entrance tracking routine during
+the linking phase (link against trm.o), as well as be post-processed with
+.IR ulp_post (1):
+.IP
+.EX
+\&
+$ gcc library.c trm.o -o library.so \\
+      -shared -fPIC \\
+      -fpatchable-function-entry=40,38
+$ ulp_post library.so
+.EE
+.PP
+Next, a program that uses the library:
+.TP
+.B Program source
+.EX
+\&
+#include <stdio.h>
+#include <unistd.h>
+
+char *proverb(void);
+
+int
+main(void)
+{
+  char buffer[128];
+
+  printf("%d\\n", getpid());
+  while (fgets(buffer, sizeof(buffer), stdin))
+    printf("%s\\n", proverb());
+
+  return 0;
+}
+.EE
+.PP
+Applications themselves do not require rebuilds, but for the sake of
+completeness, commands to build an application and link it to a library in a
+non-default location are shown below:
+.IP
+.EX
+\&
+$ gcc program.c -L$PWD -lrary -Wl,-rpath=$PWD -o program
+.EE
+.PP
+After startup, the program prints its own PID, which will be used further down
+in this example. Also, hitting ENTER causes the program to call into the
+library, which responds with a message.
+.IP
+.EX
+\&
+$ LD_PRELOAD=libpulp.so ./program
+libpulp loaded...
+12345
+<ENTER>
+Birds of a feather flock together
+<ENTER>
+An apple a day keeps the doctor away
+(and so on...)
+.EE
+.PP
+Next, recall that a live patch can only replace entire functions (see Patch
+Granularity), thus the following live patch source provides a reimplementation
+of the
+.I proverbs
+function, giving it a different name to avoid clashes:
+.TP
+.B Live patch source
+.EX
+\&
+#include <string.h>
+
+char *
+proverb_v2(void)
+{
+  return strdup("All good things must come to an end");
+}
+.EE
+.PP
+Live patches must be built like shared libraries (notice the use of the
+.I -shared
+option):
+.IP
+.EX
+\&
+$ gcc livepatch.c -shared -fPIC -o livepatch.so
+.EE
+.PP
+Next, recall that a live patch is not only composed of the object created
+above; it also requires a metadata file, which lets Libpulp know which library
+the live patch refers to, as well as it provides the correlation between
+original and replaced functions. A metadata file is built out of a description
+file.
+.TP
+.B Description file
+.EX
+\&
+/absolute/path/to/livepatch.so
+@/absolute/path/to/library.so
+proverb:proverb_v2
+.EE
+.PP
+Converting from description to metadata is accomplished with
+.IR ulp_packer (1):
+.IP
+.EX
+\&
+$ ulp_packer livepatch.dsc -o livepatch.ulp
+.EE
+.PP
+Finally,
+.IR ulp_trigger (1)
+can be used to connect to the target process and apply the live patch:
+.IP
+.EX
+\&
+$ ulp_trigger -p 12345 livepatch.ulp
+.EE
+.PP
+Wrapping up, the target process is now live patched and should behave
+differently when ENTER is hit in its controlling terminal:
+.IP
+.EX
+\&
+(...)
+<ENTER>
+All good things must come to an end
+<ENTER>
+All good things must come to an end
+.EE
+.SH BUGS
+.\" XXX: Library entrance tracking is likely to be removed from the project.
+In order to track whether each thread in the process is within the target
+library or not, Libpulp steals a frame from the call stack. Since the stolen
+frame overwrites the return address on the stack, it breaks unwinding, which
+has the undesired side-effect of breaking thread cancellation and exception
+handling. Thus, only libraries that do not throw exceptions can be made live
+patchable. Likewise, programs that cancel threads (see
+.IR pthread_cancel (3))
+will break if linked against live patchable libraries.
+.SH SEE ALSO
+.BR ptrace (2),
+.BR ulp_packer (1),
+.BR ulp_reverse (1),
+.BR ulp_dump (1),
+.BR ulp_post (1),
+.BR ulp_trigger (1),
+.BR ulp_check (1).

--- a/man/ulp_check.1
+++ b/man/ulp_check.1
@@ -1,0 +1,94 @@
+.\" libpulp - User-space Livepatching Library
+.\"
+.\" Copyright (C) 2021 SUSE Software Solutions GmbH
+.\"
+.\" This file is part of libpulp.
+.\"
+.\" libpulp is free software; you can redistribute it and/or
+.\" modify it under the terms of the GNU Lesser General Public
+.\" License as published by the Free Software Foundation; either
+.\" version 2.1 of the License, or (at your option) any later version.
+.\"
+.\" libpulp is distributed in the hope that it will be useful,
+.\" but WITHOUT ANY WARRANTY; without even the implied warranty of
+.\" MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+.\" Lesser General Public License for more details.
+.\"
+.\" You should have received a copy of the GNU General Public License
+.\" along with libpulp.  If not, see <http://www.gnu.org/licenses/>.
+
+.TH ULP_CHECK 1 "" "" "Libpulp Tools"
+.SH NAME
+ulp_check \- Apply a live patch
+.SH SYNOPSIS
+.B ulp_check
+[OPTION]...
+.BR -p pid
+.I file
+.SH DESCRIPTION
+.B ulp_check
+attaches to the target process specified by
+.I pid
+and checks whether the live patch described by the metadata
+.I file
+that it takes as argument has already been applied or not.
+.PP
+Only relevant processes can be inspected with
+.BR ulp_check .
+More specifically, the following conditions must be met:
+.TP
+.B Attaching to the Target Process
+Libpulp uses ptrace to attach to target processes, thus only the owner of a
+process (or root) can apply a live patch to it. Moreover, on systems that have
+Linux Security Modules (LSM) enabled, some extra convincing might be required
+(see Ptrace access mode checking in
+.IR ptrace (2)).
+When
+.B ulp_check
+is unable to attach to the target process, it exits in error.
+.TP
+.B Runtime support
+Applying a live patch requires functions from libpulp.so, which must have been
+loaded into the address space of the target process. Typically, this is
+accomplished with LD_PRELOAD (see
+.IR libpulp (7)).
+.SH FATAL ERRORS
+If a problem happens during the execution of functions from libpulp.so, the
+target process might end up in an inconsistent state. When that happens
+.B ulp_check
+exits with error code
+.BR -1 ,
+and the user is advised to kill the process.
+.SH OPTIONS
+.TP
+.B -q, --quiet
+Do not produce any output.
+.TP
+.B -v, --verbose
+Produce verbose output.
+.TP
+.B -?, --help
+Display a lengthy usage message.
+.TP
+.B -usage
+Display a brief usage message.
+.TP
+.B -V --version
+Print program version and exit.
+.SH BUGS
+.B ulp_check
+also returns -1 on non-fatal errors.
+.SH EXIT STATUS
+.B ulp_check
+.\" XXX: ulp_check curretly returns -1 on non-fatal errors.
+exits 0 on success, 1 on error, and -1 on fatal errors. A fatal error is an
+indication that the target process should be killed, because it was probably
+left in an inconsistent state.
+.SH SEE ALSO
+.BR libpulp (7),
+.BR ulp_packer (1),
+.BR ulp_reverse (1),
+.BR ulp_dump (1),
+.BR ulp_post (1),
+.BR ulp_trigger (1),
+.BR ulp_check (1).

--- a/man/ulp_dump.1
+++ b/man/ulp_dump.1
@@ -1,0 +1,43 @@
+.\" libpulp - User-space Livepatching Library
+.\"
+.\" Copyright (C) 2021 SUSE Software Solutions GmbH
+.\"
+.\" This file is part of libpulp.
+.\"
+.\" libpulp is free software; you can redistribute it and/or
+.\" modify it under the terms of the GNU Lesser General Public
+.\" License as published by the Free Software Foundation; either
+.\" version 2.1 of the License, or (at your option) any later version.
+.\"
+.\" libpulp is distributed in the hope that it will be useful,
+.\" but WITHOUT ANY WARRANTY; without even the implied warranty of
+.\" MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+.\" Lesser General Public License for more details.
+.\"
+.\" You should have received a copy of the GNU General Public License
+.\" along with libpulp.  If not, see <http://www.gnu.org/licenses/>.
+
+.TH ULP_DUMP 1 "" "" "Libpulp Tools"
+.SH NAME
+ulp_dump \- Prints metadata information in human-readable format
+.SH SYNOPSIS
+.B ulp_dump
+.I file
+.SH DESCRIPTION
+.B ulp_dump
+parses the metadata
+.I file
+that it takes as argument, which is in binary format, then prints its content
+to the standard output in human-readable format.
+.PP
+.SH EXIT STATUS
+.B ulp_dump
+exits 0 on success and 1 on error.
+.SH SEE ALSO
+.BR libpulp (7),
+.BR ulp_packer (1),
+.BR ulp_reverse (1),
+.BR ulp_dump (1),
+.BR ulp_post (1),
+.BR ulp_trigger (1),
+.BR ulp_check (1).

--- a/man/ulp_packer.1
+++ b/man/ulp_packer.1
@@ -1,0 +1,82 @@
+.\" libpulp - User-space Livepatching Library
+.\"
+.\" Copyright (C) 2021 SUSE Software Solutions GmbH
+.\"
+.\" This file is part of libpulp.
+.\"
+.\" libpulp is free software; you can redistribute it and/or
+.\" modify it under the terms of the GNU Lesser General Public
+.\" License as published by the Free Software Foundation; either
+.\" version 2.1 of the License, or (at your option) any later version.
+.\"
+.\" libpulp is distributed in the hope that it will be useful,
+.\" but WITHOUT ANY WARRANTY; without even the implied warranty of
+.\" MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+.\" Lesser General Public License for more details.
+.\"
+.\" You should have received a copy of the GNU General Public License
+.\" along with libpulp.  If not, see <http://www.gnu.org/licenses/>.
+
+.TH ULP_PACKER 1 "" "" "Libpulp Tools"
+.SH NAME
+ulp_packer \- Create live patch metadata
+.SH SYNOPSIS
+.B ulp_packer
+[OPTION]...
+.I file
+.SH DESCRIPTION
+.B ulp_packer
+creates a live patch metadata file based on the live patch description
+.I file
+that it takes as argument.
+After parsing the description file,
+.B ulp_packer
+validates that the target library and live patch objects referred to exist,
+then produces the metadata file required by live patching tools, such as
+.BR ulp_trigger (1)
+and
+.BR ulp_check (1).
+.PP
+The syntax of the description file is described in
+.IR libpulp (7).
+.PP
+By default, the output is written to stdout, but it can be optionally
+redirected to a specified file. See OPTIONS below.
+.SH OPTIONS
+.TP
+.B -o, --output=FILENAME
+Instead of printing the results to the standard output, write them to FILENAME.
+.TP
+.B -p, --livepatch=FILENAME
+Instead of getting the path to the live patch object from the description file,
+use FILENAME.
+.TP
+.B -t, --target=FILENAME
+Instead of getting the path to the target library from the description file,
+use FILENAME.
+.TP
+.B -q, --quiet
+Do not produce any output.
+.TP
+.B -v, --verbose
+Produce verbose output.
+.TP
+.B -?, --help
+Display a lengthy usage message.
+.TP
+.B -usage
+Display a brief usage message.
+.TP
+.B -V --version
+Print program version and exit.
+.SH EXIT STATUS
+.B ulp_packer
+exits 0 on success and 1 on error.
+.SH SEE ALSO
+.BR libpulp (7),
+.BR ulp_packer (1),
+.BR ulp_reverse (1),
+.BR ulp_dump (1),
+.BR ulp_post (1),
+.BR ulp_trigger (1),
+.BR ulp_check (1).

--- a/man/ulp_post.1
+++ b/man/ulp_post.1
@@ -1,0 +1,59 @@
+.\" libpulp - User-space Livepatching Library
+.\"
+.\" Copyright (C) 2021 SUSE Software Solutions GmbH
+.\"
+.\" This file is part of libpulp.
+.\"
+.\" libpulp is free software; you can redistribute it and/or
+.\" modify it under the terms of the GNU Lesser General Public
+.\" License as published by the Free Software Foundation; either
+.\" version 2.1 of the License, or (at your option) any later version.
+.\"
+.\" libpulp is distributed in the hope that it will be useful,
+.\" but WITHOUT ANY WARRANTY; without even the implied warranty of
+.\" MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+.\" Lesser General Public License for more details.
+.\"
+.\" You should have received a copy of the GNU General Public License
+.\" along with libpulp.  If not, see <http://www.gnu.org/licenses/>.
+
+.TH ULP_POST 1 "" "" "Libpulp Tools"
+.SH NAME
+ulp_post \- Install libpulp trampolines in target libraries
+.SH SYNOPSIS
+.B ulp_post
+.I file
+.SH DESCRIPTION
+.B ulp_post
+opens the library
+.I file
+passed as argument and installs trampolines to every exported function that has
+a patchable function entry (see
+.IR gcc (1)).
+The trampolines divert control to the library entrance tracking routine, which
+performs its role then retransfers control to the target function. Entrance
+information is used by Libpulp to determine when to switch between versions of
+live patched functions.
+.SH BUGS
+.\" XXX: Library entrance tracking is likely to be removed from the project.
+In order to track whether each thread in the process is within the target
+library or not, the trampolines installed by
+.I ulp_post
+steal a frame from the call stack. Since the stolen frame overwrites the return
+address on the stack, it breaks unwinding, which has the undesired side-effect
+of breaking thread cancellation and exception handling. Thus, only libraries
+that do not throw exceptions can be made live patchable. Likewise, programs
+that cancel threads (see
+.IR pthread_cancel (3))
+will break if linked against live patchable libraries.
+.SH EXIT STATUS
+.B ulp_post
+exits 0 on success, and 1 on error.
+.SH SEE ALSO
+.BR libpulp (7),
+.BR ulp_packer (1),
+.BR ulp_reverse (1),
+.BR ulp_dump (1),
+.BR ulp_post (1),
+.BR ulp_trigger (1),
+.BR ulp_check (1).

--- a/man/ulp_reverse.1
+++ b/man/ulp_reverse.1
@@ -1,0 +1,46 @@
+.\" libpulp - User-space Livepatching Library
+.\"
+.\" Copyright (C) 2021 SUSE Software Solutions GmbH
+.\"
+.\" This file is part of libpulp.
+.\"
+.\" libpulp is free software; you can redistribute it and/or
+.\" modify it under the terms of the GNU Lesser General Public
+.\" License as published by the Free Software Foundation; either
+.\" version 2.1 of the License, or (at your option) any later version.
+.\"
+.\" libpulp is distributed in the hope that it will be useful,
+.\" but WITHOUT ANY WARRANTY; without even the implied warranty of
+.\" MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+.\" Lesser General Public License for more details.
+.\"
+.\" You should have received a copy of the GNU General Public License
+.\" along with libpulp.  If not, see <http://www.gnu.org/licenses/>.
+
+.TH ULP_REVERSE 1 "" "" "Libpulp Tools"
+.SH NAME
+ulp_reverse \- Create live patch metadata
+.SH SYNOPSIS
+.B ulp_reverse
+.I file
+.SH DESCRIPTION
+.B ulp_reverse
+creates a live patch metadata used to revert the effects of the metadata
+.I file
+that it takes as argument.
+Live patch reversal does not require a live patch object file, because it does
+not add new replacement functions; rather, it causes the reverse-patched
+process to fallback to the functions that had been previously replaced. These
+functions are already present in the memory space of the target process.
+.PP
+.SH EXIT STATUS
+.B ulp_reverse
+exits 0 on success and a positive integer on error.
+.SH SEE ALSO
+.BR libpulp (7),
+.BR ulp_packer (1),
+.BR ulp_reverse (1),
+.BR ulp_dump (1),
+.BR ulp_post (1),
+.BR ulp_trigger (1),
+.BR ulp_check (1).

--- a/man/ulp_trigger.1
+++ b/man/ulp_trigger.1
@@ -1,0 +1,136 @@
+.\" libpulp - User-space Livepatching Library
+.\"
+.\" Copyright (C) 2021 SUSE Software Solutions GmbH
+.\"
+.\" This file is part of libpulp.
+.\"
+.\" libpulp is free software; you can redistribute it and/or
+.\" modify it under the terms of the GNU Lesser General Public
+.\" License as published by the Free Software Foundation; either
+.\" version 2.1 of the License, or (at your option) any later version.
+.\"
+.\" libpulp is distributed in the hope that it will be useful,
+.\" but WITHOUT ANY WARRANTY; without even the implied warranty of
+.\" MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+.\" Lesser General Public License for more details.
+.\"
+.\" You should have received a copy of the GNU General Public License
+.\" along with libpulp.  If not, see <http://www.gnu.org/licenses/>.
+
+.TH ULP_TRIGGER 1 "" "" "Libpulp Tools"
+.SH NAME
+ulp_trigger \- Apply a live patch
+.SH SYNOPSIS
+.B ulp_trigger
+[OPTION]...
+.BR -p pid
+.I file
+.SH DESCRIPTION
+.B ulp_trigger
+attaches to the target process specified by
+.I pid
+and applies the live patch described by the metadata
+.I file
+that it takes as argument.
+After parsing the metadata file, several checks are performed to verify that
+the target process can receive the specified live patch:
+.TP
+.B Target Library
+A live patch replaces functions belonging to a shared library, thus,
+.B ulp_trigger
+searches the memory space of the target process for its presence. When the
+library is not present,
+.B ulp_trigger
+exits in error.
+.TP
+.B Replacement functions
+The metadata file contains a list of replacement functions, which must be
+present in the live patch object (DSO). If all functions are present, the live
+patching operation can proceed, otherwise
+.B ulp_trigger
+exits in error.
+.TP
+.B Attaching to the Target Process
+Libpulp uses ptrace to attach to target processes, thus only the owner of a
+process (or root) can apply a live patch to it. Moreover, on systems that have
+Linux Security Modules (LSM) enabled, some extra convincing might be required
+(see Ptrace access mode checking in
+.IR ptrace (2)).
+When
+.B ulp_trigger
+is unable to attach to the target process, it exits in error.
+.TP
+.B Runtime support
+Applying a live patch requires functions from libpulp.so, which must have been
+loaded into the address space of the target process. Typically, this is
+accomplished with LD_PRELOAD (see
+.IR libpulp (7)).
+.TP
+.B Forward progress
+After attaching to the target process with ptrace, Libpulp calls functions from
+libpulp.so. The execution of these functions happens from the context of a
+signal handler, thus
+.I AS-Unsafe
+functions are not allowed (see
+.IR attributes (7)).
+However, Libpulp requires the use of
+.IR malloc (3),
+.IR dlopen (3)
+and
+.IR dlsym (3),
+which are all
+.IR AS-Unsafe .
+In order to avoid deadlocks, libpulp.so checks that these functions are not in
+execution anywhere in the target process, before starting the live patching
+operation.
+.SH FATAL ERRORS
+If a problem happens after Libpulp started replacing functions from the target
+process, the process might end up in an inconsistent state. When that happens
+.B ulp_trigger
+exits with error code
+.BR -1 ,
+and the user is advised to kill the process.
+.SH OPTIONS
+.TP
+.B -r, --retries=N
+To guarantee
+.BR "Forward Progress" ,
+Libpulp first checks whether trying to apply a live patch would cause a
+deadlock in the target process, or if it would be safe to do so. By default,
+.B ulp_trigger
+performs this check a single time and exits in error if the check fails.
+However, the state of the relevant locks usually changes very quickly, thus,
+there is a high chance that trying again after a brief moment would allow the
+live patching operation to succeed without risk of deadlock. This option tells
+.B ulp_trigger
+to try again
+.I N
+times.
+.TP
+.B -q, --quiet
+Do not produce any output.
+.TP
+.B -v, --verbose
+Produce verbose output.
+.TP
+.B -?, --help
+Display a lengthy usage message.
+.TP
+.B -usage
+Display a brief usage message.
+.TP
+.B -V --version
+Print program version and exit.
+.SH EXIT STATUS
+.B ulp_trigger
+exits 0 on success, 1 on error, and -1 on fatal errors. A fatal error is an
+indication that the target process should be killed, because it was probably
+left in an inconsistent state.
+.SH SEE ALSO
+.BR libpulp (7),
+.BR ulp_packer (1),
+.BR ulp_reverse (1),
+.BR ulp_dump (1),
+.BR ulp_post (1),
+.BR ulp_trigger (1),
+.BR ulp_check (1).


### PR DESCRIPTION
Even though most of the tools already provide a --help, their
relationship is not clear. This patch adds manpages to each of the
tools, as well as an overview page with examples.