### PR TITLE
Add support for unexported variables access in live patches

### DIFF
--- a/Makefile.common
+++ b/Makefile.common
@@ -46,12 +46,14 @@ CONVENIENCE_LDFLAGS = -rpath $(libdir) $(AM_LDFLAGS)
 	$(ULP_POST) .libs/lib$*.so
 	touch $@
 
-# These rules cause the livepatch metadata to be built.  The .ulp target
-# depends on check_LTLIBRARIES, because .la targets indirectly produce
-# the .so files they need (it is impossible to have .ulp targets depend
-# directly on .so files, because libtool does not create .so targets).
-%.dsc: %.in
-	sed -e "s|__ABS_BUILDDIR__|$(abs_builddir)|" $^ > $@
+# These rules cause the livepatch metadata to be built. The .ulp and
+# .dsc targets depends on check_LTLIBRARIES, because .la targets
+# indirectly produce the .so files they need (it is impossible to have
+# .ulp and .dsc targets depend directly on .so files, because libtool
+# does not create .so targets).
+%.dsc: %.in $(check_LTLIBRARIES)
+	sed -e "s|__ABS_BUILDDIR__|$(abs_builddir)|" $< > $*.tmp
+	$(top_srcdir)/tests/offsets.py $*.tmp $@
 
 %.ulp: %.dsc $(check_LTLIBRARIES)
 	$(ULP_PACKER) $< -o $@

--- a/include/ulp_common.h
+++ b/include/ulp_common.h
@@ -48,6 +48,8 @@ struct ulp_metadata
   struct ulp_object *objs;
   uint32_t ndeps;
   struct ulp_dependency *deps;
+  uint32_t nrefs;
+  struct ulp_reference *refs;
   uint8_t type;
 };
 
@@ -76,6 +78,15 @@ struct ulp_dependency
   unsigned char dep_id[32];
   char patch_id_check;
   struct ulp_dependency *next;
+};
+
+struct ulp_reference
+{
+  char *target_name;
+  char *reference_name;
+  uintptr_t target_offset;
+  uintptr_t patch_offset;
+  struct ulp_reference *next;
 };
 
 #endif

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -136,6 +136,16 @@ libexception_la_LDFLAGS = $(TARGET_LDFLAGS) $(CONVENIENCE_LDFLAGS)
 
 POST_PROCESS += .libs/libexception.post
 
+# Target libraries to test static data access
+check_LTLIBRARIES += libaccess.la
+noinst_HEADERS += libaccess.h
+
+libaccess_la_SOURCES = libaccess.c
+libaccess_la_CFLAGS = $(TARGET_CFLAGS)
+libaccess_la_LDFLAGS = $(TARGET_LDFLAGS) $(CONVENIENCE_LDFLAGS)
+
+POST_PROCESS += .libs/libaccess.post
+
 # Live patches
 check_LTLIBRARIES += libdozens_livepatch1.la \
                      libdozens_livepatch99.la \
@@ -148,7 +158,8 @@ check_LTLIBRARIES += libdozens_livepatch1.la \
                      libblocked_livepatch1.la \
                      libpagecross_livepatch1.la \
                      libaddress_livepatch1.la \
-                     libcontract_livepatch1.la
+                     libcontract_livepatch1.la \
+                     libaccess_livepatch1.la
 
 libdozens_livepatch1_la_SOURCES = libdozens_livepatch1.c
 libdozens_livepatch1_la_LDFLAGS = $(CONVENIENCE_LDFLAGS)
@@ -186,6 +197,9 @@ libaddress_livepatch1_la_LDFLAGS = $(CONVENIENCE_LDFLAGS)
 libcontract_livepatch1_la_SOURCES = libcontract_livepatch1.c
 libcontract_livepatch1_la_LDFLAGS = $(CONVENIENCE_LDFLAGS)
 
+libaccess_livepatch1_la_SOURCES = libaccess_livepatch1.c
+libaccess_livepatch1_la_LDFLAGS = $(CONVENIENCE_LDFLAGS)
+
 METADATA = \
   libdozens_livepatch1.dsc \
   libdozens_livepatch1.ulp \
@@ -222,7 +236,10 @@ METADATA = \
   libaddress_livepatch1.rev \
   libcontract_livepatch1.dsc \
   libcontract_livepatch1.ulp \
-  libcontract_livepatch1.rev
+  libcontract_livepatch1.rev \
+  libaccess_livepatch1.dsc \
+  libaccess_livepatch1.ulp \
+  libaccess_livepatch1.rev
 
 EXTRA_DIST = \
   libdozens_livepatch1.in \
@@ -236,7 +253,8 @@ EXTRA_DIST = \
   libblocked_livepatch1.in \
   libpagecross_livepatch1.in \
   libaddress_livepatch1.in \
-  libcontract_livepatch1.in
+  libcontract_livepatch1.in \
+  libaccess_livepatch1.in
 
 clean-local:
 	rm -f $(METADATA)
@@ -259,7 +277,8 @@ check_PROGRAMS = \
   constructor \
   cancel \
   contract \
-  exception_handling
+  exception_handling \
+  access
 
 numserv_SOURCES = numserv.c
 numserv_LDADD = libdozens.la libhundreds.la
@@ -338,6 +357,10 @@ exception_handling_SOURCES = exception_handling.cc
 exception_handling_LDADD = libexception.la
 exception_handling_DEPENDENCIES = $(POST_PROCESS) $(METADATA)
 
+access_SOURCES = access.c
+access_LDADD = libaccess.la
+access_DEPENDENCIES = $(POST_PROCESS) $(METADATA)
+
 TESTS = \
   numserv.py \
   numserv_bsymbolic.py \
@@ -356,7 +379,8 @@ TESTS = \
   constructor.py \
   cancel.py \
   contract.py \
-  exception_handling.py
+  exception_handling.py \
+  access.py
 
 XFAIL_TESTS = \
   blocked.py \

--- a/tests/access.c
+++ b/tests/access.c
@@ -1,0 +1,57 @@
+/*
+ *  libpulp - User-space Livepatching Library
+ *
+ *  Copyright (C) 2021 SUSE Software Solutions GmbH
+ *
+ *  This file is part of libpulp.
+ *
+ *  libpulp is free software; you can redistribute it and/or
+ *  modify it under the terms of the GNU Lesser General Public
+ *  License as published by the Free Software Foundation; either
+ *  version 2.1 of the License, or (at your option) any later version.
+ *
+ *  libpulp is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ *  Lesser General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with libpulp.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <errno.h>
+#include <stdio.h>
+#include <string.h>
+
+#include <libaccess.h>
+
+int
+main(void)
+{
+  char buffer[128];
+
+  /* Original banner. */
+  printf("%s\n", banner_get());
+
+  /* Use original banner setting function. */
+  banner_set(strdup("Banner changed from main"));
+  printf("%s\n", banner_get());
+
+  /* Wait for input. */
+  if (fgets(buffer, sizeof(buffer), stdin) == NULL) {
+    if (errno) {
+      perror("access");
+      return 1;
+    }
+  }
+
+  /*
+   * Use banner setting function again, which is supposed to have been
+   * changed by the test driver. The patched function ignores the
+   * argument, so 'String from main' should not be in the output.
+   */
+  banner_set("String from main");
+  printf("%s\n", banner_get());
+
+  return 0;
+}

--- a/tests/access.py
+++ b/tests/access.py
@@ -1,0 +1,37 @@
+#!/usr/bin/env python3
+
+#   libpulp - User-space Livepatching Library
+#
+#   Copyright (C) 2021 SUSE Software Solutions GmbH
+#
+#   This file is part of libpulp.
+#
+#   libpulp is free software; you can redistribute it and/or
+#   modify it under the terms of the GNU Lesser General Public
+#   License as published by the Free Software Foundation; either
+#   version 2.1 of the License, or (at your option) any later version.
+#
+#   libpulp is distributed in the hope that it will be useful,
+#   but WITHOUT ANY WARRANTY; without even the implied warranty of
+#   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+#   Lesser General Public License for more details.
+#
+#   You should have received a copy of the GNU General Public License
+#   along with libpulp.  If not, see <http://www.gnu.org/licenses/>.
+
+import testsuite
+
+child = testsuite.spawn(testsuite.testname)
+
+child.expect('Original banner')
+child.expect('Banner changed from main')
+
+child.livepatch('libaccess_livepatch1.ulp')
+
+child.sendline('')
+child.expect('String from live patch',
+             reject=['String from main',
+                     'Live patch data references not initialized'])
+
+child.close(force=True)
+exit(0)

--- a/tests/libaccess.c
+++ b/tests/libaccess.c
@@ -1,0 +1,38 @@
+/*
+ *  libpulp - User-space Livepatching Library
+ *
+ *  Copyright (C) 2021 SUSE Software Solutions GmbH
+ *
+ *  This file is part of libpulp.
+ *
+ *  libpulp is free software; you can redistribute it and/or
+ *  modify it under the terms of the GNU Lesser General Public
+ *  License as published by the Free Software Foundation; either
+ *  version 2.1 of the License, or (at your option) any later version.
+ *
+ *  libpulp is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ *  Lesser General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with libpulp.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <string.h>
+
+#include <libaccess.h>
+
+static char *banner = "Original banner";
+
+char *
+banner_get(void)
+{
+  return banner;
+}
+
+void
+banner_set(char *new)
+{
+  banner = new;
+}

--- a/tests/libaccess.h
+++ b/tests/libaccess.h
@@ -1,0 +1,23 @@
+/*
+ *  libpulp - User-space Livepatching Library
+ *
+ *  Copyright (C) 2021 SUSE Software Solutions GmbH
+ *
+ *  This file is part of libpulp.
+ *
+ *  libpulp is free software; you can redistribute it and/or
+ *  modify it under the terms of the GNU Lesser General Public
+ *  License as published by the Free Software Foundation; either
+ *  version 2.1 of the License, or (at your option) any later version.
+ *
+ *  libpulp is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ *  Lesser General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with libpulp.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+char *banner_get(void);
+void banner_set(char *);

--- a/tests/libaccess_livepatch1.c
+++ b/tests/libaccess_livepatch1.c
@@ -1,0 +1,37 @@
+/*
+ *  libpulp - User-space Livepatching Library
+ *
+ *  Copyright (C) 2021 SUSE Software Solutions GmbH
+ *
+ *  This file is part of libpulp.
+ *
+ *  libpulp is free software; you can redistribute it and/or
+ *  modify it under the terms of the GNU Lesser General Public
+ *  License as published by the Free Software Foundation; either
+ *  version 2.1 of the License, or (at your option) any later version.
+ *
+ *  libpulp is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ *  Lesser General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with libpulp.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <err.h>
+#include <stdlib.h>
+
+#include <libaccess.h>
+
+static char **ulpr_banner = NULL;
+static char *ulpr_string = "String from live patch";
+
+void
+new_banner_set(__attribute__((unused))char *new)
+{
+  if (ulpr_banner == NULL)
+    errx(EXIT_FAILURE, "Live patch data references not initialized");
+
+  *ulpr_banner = ulpr_string;
+}

--- a/tests/libaccess_livepatch1.in
+++ b/tests/libaccess_livepatch1.in
@@ -1,0 +1,4 @@
+__ABS_BUILDDIR__/.libs/libaccess_livepatch1.so
+@__ABS_BUILDDIR__/.libs/libaccess.so.0
+banner_set:new_banner_set
+#banner:ulpr_banner:__TARGET_OFFSET__:__PATCH_OFFSET__

--- a/tests/offsets.py
+++ b/tests/offsets.py
@@ -4,6 +4,7 @@ import argparse
 import subprocess
 
 def find_offset(file, name):
+  print('looking for:', name)
   nm = subprocess.Popen(['nm', file], stdout=subprocess.PIPE,
                         encoding='utf-8')
   for entry in nm.stdout.readlines():
@@ -13,7 +14,9 @@ def find_offset(file, name):
     symbol = split[2].rstrip('\n')
     print('symbol:', symbol)
     if symbol == name:
+      print('found')
       return split[0]
+    print('not found')
   return
 
 # This program takes two arguments, first the path to the input file, then the

--- a/tests/offsets.py
+++ b/tests/offsets.py
@@ -1,0 +1,73 @@
+#!/usr/bin/env python3
+
+import argparse
+import subprocess
+
+def find_offset(file, name):
+  nm = subprocess.Popen(['nm', file], stdout=subprocess.PIPE,
+                        encoding='utf-8')
+  for entry in nm.stdout.readlines():
+    split = entry.split(sep=' ')
+    symbol = split[2].rstrip('\n')
+    if symbol == name:
+      return split[0]
+  return
+
+# This program takes two arguments, first the path to the input file, then the
+# path to the output file. The input file is a live patch description template,
+# where every line starting with '#' contains a local (not-exported) variable
+# whose address in the target library (__TARGET_OFFSET__), as well as the
+# address of its reference in the live patch (__PATCH_OFFSET__) must be
+# determined.
+parser = argparse.ArgumentParser()
+parser.add_argument('ifile')
+parser.add_argument('ofile')
+args = parser.parse_args()
+
+ifile = open(args.ifile, 'r')
+ofile = open(args.ofile, 'w')
+
+# The path to the patch file is always at the first line
+patch = ifile.readline()
+patch = patch.rstrip('\n')
+
+# The path to the target library is always at the second line,
+# which always starts with '@'
+target = ifile.readline()
+target = target.rstrip('\n')
+target = target.lstrip('@')
+
+# Rewind the input file
+ifile.seek(0)
+
+# Iterate over all lines of the input file
+for line in ifile:
+
+  # Lines starting with '#' contain local variables
+  if line[0] == '#':
+
+    # Parse the line
+    split = line.lstrip('#')
+    split = split.split(':')
+
+    # Get the name of the local variable in the target library
+    tname = split[0]
+
+    # Get the name of the local variable reference in the live patch
+    pname = split[1]
+
+    # Search for the local variable in the target library
+    toff = find_offset(target, tname)
+
+    # Search for the local variable reference in the live patch
+    poff = find_offset(patch, pname)
+
+    # Replace offset template patterns with actual offsets
+    line = line.replace('__TARGET_OFFSET__', toff)
+    line = line.replace('__PATCH_OFFSET__', poff)
+
+  # Write every line back to the output file
+  ofile.write(line)
+
+ifile.close()
+ofile.close()

--- a/tests/offsets.py
+++ b/tests/offsets.py
@@ -7,8 +7,11 @@ def find_offset(file, name):
   nm = subprocess.Popen(['nm', file], stdout=subprocess.PIPE,
                         encoding='utf-8')
   for entry in nm.stdout.readlines():
+    print('entry:', entry)
     split = entry.split(sep=' ')
+    print('split:', split)
     symbol = split[2].rstrip('\n')
+    print('symbol:', symbol)
     if symbol == name:
       return split[0]
   return

--- a/tools/packer.c
+++ b/tools/packer.c
@@ -287,6 +287,7 @@ create_patch_metadata_file(struct ulp_metadata *ulp, char *filename)
   struct ulp_unit *unit;
   struct ulp_object *obj;
   struct ulp_dependency *dep;
+  struct ulp_reference *ref;
   uint32_t c;
   uint8_t type = 1;
 
@@ -344,12 +345,31 @@ create_patch_metadata_file(struct ulp_metadata *ulp, char *filename)
 
     /* to-be-patched function addrs */
     fwrite(&unit->old_faddr, sizeof(void *), 1, file);
+    fflush(file);
   }
+  fflush(file);
 
   fwrite(&ulp->ndeps, sizeof(uint32_t), 1, file);
 
   for (dep = ulp->deps; dep != NULL; dep = dep->next) {
     fwrite(&dep->dep_id, sizeof(char), 32, file);
+  }
+  fflush(file);
+
+  fwrite(&ulp->nrefs, sizeof(uint32_t), 1, file);
+  fflush(file);
+
+  for (ref = ulp->refs; ref != NULL; ref = ref->next) {
+    uint32_t len;
+    len = strlen(ref->target_name);
+    fwrite(&len, sizeof(len), 1, file);
+    fwrite(ref->target_name, sizeof(char), len, file);
+    len = strlen(ref->reference_name);
+    fwrite(&len, sizeof(len), 1, file);
+    fwrite(ref->reference_name, sizeof(char), len, file);
+    fwrite(&ref->target_offset, sizeof(ref->target_offset), 1, file);
+    fwrite(&ref->patch_offset, sizeof(ref->patch_offset), 1, file);
+    fflush(file);
   }
 
   return 1;
@@ -398,9 +418,11 @@ parse_description(char *filename, struct ulp_metadata *ulp)
 {
   struct ulp_unit *unit, *last_unit;
   struct ulp_dependency *dep;
+  struct ulp_reference *ref;
   FILE *file;
   char *first;
   char *second;
+  char *third;
   size_t i, len = 0;
   int n;
 
@@ -490,46 +512,86 @@ parse_description(char *filename, struct ulp_metadata *ulp)
       if (first[n - 1] == '\n')
         first[n - 1] = '\0';
 
-      /* find old/new function name separator */
-      for (i = 0; i < len; i++) {
-        if (first[i] == ':') {
-          first[i] = '\0';
-          second = &first[i + 1];
+      /* Lines starting with # are static data references */
+      if (first[0] == '#') {
+
+        ref = calloc(1, sizeof(struct ulp_reference));
+        if (!ref) {
+          WARN("Unable to allocate memory");
+          return 0;
         }
+
+        third = first + 1;
+        second = strchr(third, ':');
+        *second = '\0';
+        ref->target_name = strdup(third);
+
+        third = second + 1;
+        second = strchr(third, ':');
+        *second = '\0';
+        ref->reference_name = strdup(third);
+
+        third = second + 1;
+        second = strchr(third, ':');
+        *second = '\0';
+        ref->target_offset = (intptr_t)strtol(third, NULL, 16);
+
+        third = second + 1;
+        ref->patch_offset = (intptr_t)strtol(third, NULL, 16);
+
+        ref->next = ulp->refs;
+        ulp->refs = ref;
+        ulp->nrefs++;
       }
 
-      if (!second) {
-        WARN("Invalid input description.");
-        return 0;
-      }
+      /*
+       * Lines not starting with # contain the names of replacement and
+       * replaced functions.
+       */
+      else
+        {
 
-      /* allocate and fill patch unit */
-      unit = calloc(1, sizeof(struct ulp_unit));
-      if (!unit) {
-        WARN("Unable to allocate memory for parsing ulp units.");
-        return 0;
-      }
+        /* find old/new function name separator */
+        for (i = 0; i < len; i++) {
+          if (first[i] == ':') {
+            first[i] = '\0';
+            second = &first[i + 1];
+          }
+        }
 
-      unit->old_fname = strdup(first);
-      if (!unit->old_fname) {
-        WARN("Unable to allocate memory for parsing ulp units.");
-        return 0;
-      }
+        if (!second) {
+          WARN("Invalid input description.");
+          return 0;
+        }
 
-      unit->new_fname = strdup(second);
-      if (!unit->old_fname) {
-        WARN("Unable to allocate memory for parsing ulp units.");
-        return 0;
-      }
+        /* allocate and fill patch unit */
+        unit = calloc(1, sizeof(struct ulp_unit));
+        if (!unit) {
+          WARN("Unable to allocate memory for parsing ulp units.");
+          return 0;
+        }
 
-      if (!last_unit) {
-        ulp->objs->units = unit;
+        unit->old_fname = strdup(first);
+        if (!unit->old_fname) {
+          WARN("Unable to allocate memory for parsing ulp units.");
+          return 0;
+        }
+
+        unit->new_fname = strdup(second);
+        if (!unit->old_fname) {
+          WARN("Unable to allocate memory for parsing ulp units.");
+          return 0;
+        }
+
+        if (!last_unit) {
+          ulp->objs->units = unit;
+        }
+        else {
+          last_unit->next = unit;
+        }
+        ulp->objs->nunits++;
+        last_unit = unit;
       }
-      else {
-        last_unit->next = unit;
-      }
-      ulp->objs->nunits++;
-      last_unit = unit;
     }
 
     /* get new line */


### PR DESCRIPTION
So far, none of the live patch examples in the test suite needs access
to data objects in the target library, instead, all of them replace
functions that only deal with local variables or function arguments
(either on the stack or in registers). However, direct access to data
objects in the target library is desirable and even required by some
live patches.

If a live patch needs to access a data object that has been exported by
the target library, i.e. a GLOBAL object, the compiler toolchain is able
to generate the relocations that the loader needs. However, when the
data object has not been exported, i.e. a LOCAL object, the toolchain is
unable to generate a reference and fails with an 'undefined reference'
error message.

To bridge this gap, this patch extends the live patch metadata with
information about LOCAL data objects. The information is comprised of
the name of the variable in the target library, the name of a reference
variable in the live patch, as well as the offsets that these two data
objects have within their DSOs. The following example (taken from the
new test case added by this patch) of a live patch description file
provides a clarification:

  1. /run/user/1001/libpulp/tests/.libs/libaccess_livepatch1.so
  2. @/run/user/1001/libpulp/tests/.libs/libaccess.so.0
  3. banner_set:new_banner_set
  4. #banner:ulpr_banner:0000000000004020:0000000000004038

Lines 1 and 2 are not new and inform Libpulp about the in-disk paths to
the live patch DSO and to the target library, respectively. Line 3 is
also not new, and provides a pair of replaced and replacement functions.
Line 4 is new. It is preceded by the '#' character and divided into 4
parts, in a predefined order: 1. the name of the data object in the
target library, 'banner'; 2. the name of another data object,
'ulpr_banner', which sits within the live patch object and is used as a
reference to 'banner'; 3. the offset of 'banner' from the loading
address of the target library; 4. the offset of 'ulpr_banner' from the
loading address of the live patch object.

Then, when a live patch gets applied, Libpulp uses the aforementioned
offsets and makes 'ulpr_banner' point to the loaded address of 'banner',
which makes it possible for the live patch to access the data object in
the target library.

PS: The names of the objects (in the target library and in the live
patch) are not really necessary and, in fact, not used by Libpulp.